### PR TITLE
Add subject field to email sending functionality

### DIFF
--- a/SWP_SchoolMedicalManagementSystem_API/Controllers/AuthController.cs
+++ b/SWP_SchoolMedicalManagementSystem_API/Controllers/AuthController.cs
@@ -61,7 +61,7 @@ namespace SWP_SchoolMedicalManagementSystem_API.Controllers
         [HttpPost("send-email")]
         public async Task<IActionResult> SendEmail([FromBody] EmailMedicalDiaryCreateDto emailRequest)
         {
-            await _emailService.SendEmailAsync(emailRequest.Recipient, emailRequest.Body);
+            await _emailService.SendEmailAsync(emailRequest.Subject, emailRequest.Recipient, emailRequest.Body);
             return Ok("Email sent successfully.");
         }
     }

--- a/SWP_SchoolMedicalManagementSystem_BussinessProject/Dto/EmailDto/EmailMedicalDiaryCreateDto.cs
+++ b/SWP_SchoolMedicalManagementSystem_BussinessProject/Dto/EmailDto/EmailMedicalDiaryCreateDto.cs
@@ -2,6 +2,7 @@
 {
     public class EmailMedicalDiaryCreateDto
     {
+        public string Subject { get; set; } = string.Empty;
         public string Recipient { get; set; } = string.Empty;
         public string Body { get; set; } = string.Empty;
     }

--- a/SWP_SchoolMedicalManagementSystem_Service/Extension/EmailService.cs
+++ b/SWP_SchoolMedicalManagementSystem_Service/Extension/EmailService.cs
@@ -14,7 +14,7 @@ namespace SWP_SchoolMedicalManagementSystem_Service.Extension
             _smtpConfig = _configuration.GetSection("SMTP");
         }
 
-        public async Task SendEmailAsync(string recipient, string body)
+        public async Task SendEmailAsync(string recipient, string body, string subject)
         {
             var _smtpServer = _smtpConfig["SmtpServer"];
             var _port = int.Parse(_smtpConfig["Port"]!);
@@ -32,7 +32,7 @@ namespace SWP_SchoolMedicalManagementSystem_Service.Extension
             })
             using (var mail = new MailMessage(_senderEmail!, recipient)
             {
-                Subject = "Thông báo uống thuốc của học sinh",
+                Subject = subject,
                 Body = body,
                 IsBodyHtml = true
             })

--- a/SWP_SchoolMedicalManagementSystem_Service/Extension/IEmailService.cs
+++ b/SWP_SchoolMedicalManagementSystem_Service/Extension/IEmailService.cs
@@ -2,6 +2,6 @@
 {
     public interface IEmailService
     {
-        Task SendEmailAsync(string recipient, string body);
+        Task SendEmailAsync(string recipient, string body, string subject);
     }
 }


### PR DESCRIPTION
Introduces a 'Subject' property to EmailMedicalDiaryCreateDto and updates the email service interface and implementation to accept and use the subject when sending emails. The AuthController is updated to pass the subject from the request, allowing for customizable email subjects.